### PR TITLE
Add http compatibilty for Jeedom URL

### DIFF
--- a/MMM-Jeedom.js
+++ b/MMM-Jeedom.js
@@ -20,6 +20,7 @@ Module.register("MMM-Jeedom",{
 				customTitle: "No sensor define in config",
 			},
 		],
+		jeedomHTTPS: true
 	},
 
 	start: function() {

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ modules: [
 			      	jeedomAPIKey: "",
 				jeedomURL: "",
 				jeedomPORT: 443,
+				jeedomHTTPS: true,
 				jeedomAPIPath: "/core/api/jeeApi.php",
 				sensors: [
 				{

--- a/node_helper.js
+++ b/node_helper.js
@@ -1,5 +1,6 @@
 var NodeHelper = require("node_helper");
 const https = require('https');
+const http = require('http');
 
 module.exports = NodeHelper.create({
 	start: function() {
@@ -31,8 +32,10 @@ module.exports = NodeHelper.create({
 		    'Content-Length': Buffer.byteLength(postData)
 		 }
 		};
-		
-		var req = https.request(options, (res) => {
+
+		var protocol = refConfig.jeedomHTTPS ? https : http;
+
+		var req = protocol.request(options, (res) => {
 		  res.setEncoding('utf8');
 		  res.on('data', (chunk) => {
 		    self.sendSocketNotification("RELOAD_DONE",JSON.parse(chunk));


### PR DESCRIPTION
I added ability for module to work with HTTP and HTTPS Jeedom URL (useful for internal network).
There is a new config variable (jeedomHTTPS) to specify if Jeedom URL use HTTP or HTTPS.