### PR TITLE
Bug fix at start-up update and corrections on README

### DIFF
--- a/MMM-Jeedom.js
+++ b/MMM-Jeedom.js
@@ -52,7 +52,7 @@ Module.register("MMM-Jeedom",{
 		Log.log(this.sensors);
 
 		// first update on start
-		self.updateJeedom(); //premier update appelé par resume à l'affichage de la page, donc on peut virer celui la
+		self.updateJeedom(); 
 	},
 	
 	//Modif AgP42 - 11/07/2018	

--- a/MMM-Jeedom.js
+++ b/MMM-Jeedom.js
@@ -52,7 +52,7 @@ Module.register("MMM-Jeedom",{
 		Log.log(this.sensors);
 
 		// first update on start
-		//self.updateJeedom(); //premier update appelé par resume à l'affichage de la page, donc on peut virer celui la
+		self.updateJeedom(); //premier update appelé par resume à l'affichage de la page, donc on peut virer celui la
 	},
 	
 	//Modif AgP42 - 11/07/2018	

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Magic Mirror 2 - JEEDOM Module
 
 This module displays any JEEDOM command value. The information will be updated depending on the polling time.
-If a PIR-sensor using MMM-PIR-Sormor module is used, ths information will not be updated during screen off. 
+If a PIR-sensor using MMM-PIR-Sensor module is used, this information will not be updated during screen off. 
 The infos will also not be updated when no instances of the MMM-Jeedom module are displayed on the screen (for example hidden by using MMM-Remote-Control or any carousel like MMM-Pages). This will allow to reduce the number of request to Jeedom API. 
 As soon as one MMM-Jeedom module will be again displayed on the screen, all the instances will request an update of the datas. 
 


### PR DESCRIPTION
Remove the comment on first update on start function. 
The resume function was call at start-up on my specific installation, but not applicable to all. 
Now MMM-Jeedom will request to update data as start-up in any case. (And sometime 2 times if resume function is called by another module also...)